### PR TITLE
1234 dependabot patch label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: "daily"
     labels:
       - "patch"
+      - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "patch"


### PR DESCRIPTION
# Motivation and Context
All dependabot PRs are currently blocked because they don’t include our mandatory versioning labels, which obscures which ones pass the tests without a deeper dive.

# What has changed
Added dependabot.yml file
Added labels to the dependabot config file

# How to test?
Check I've used the correct package ecosystem for the repo
Check the labels

# Links
https://trello.com/c/ZPLTDik6

# Screenshots (if appropriate):