### PR TITLE
Add session_cookie_secure to taliman

### DIFF
--- a/rh_ui/app_setup.py
+++ b/rh_ui/app_setup.py
@@ -58,6 +58,7 @@ def create_app() -> Flask:
         strict_transport_security_max_age=31536000,
         x_content_type_options='nosniff',
         permissions_policy=PERMISSION_POLICY,
+        session_cookie_secure=app.config["SESSION_COOKIE_SECURE"]
     )
 
     return app


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
From looking at our security config, I noticed that the session_cookie_secure config is meant to be passed into talisman otherwise it's always set to true. If we do this and set it to false for CI, we should be able to get the tests pass. 

There needs to be discussion on what is the best way to handle it though. Do we allow non secure session cookies for our dev environments and make sure it's set to true for our production projects?
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Pass SESSION_COOKIE_SECURE into talisman

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run the acceptance tests locally to make sure everything still passes
- Run the acceptance tests in GCP with SESSION_COOKIE_SECURE set to false. That should allow the tests to pass.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Jira](https://jira.ons.gov.uk/browse/SDCSRM-410)
