### PR TITLE
SDCSRM-521 Add venom config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 rh_ui/templates/components/
 rh_ui/templates/layout/
 
+# Local venom resources
+tmp_venom*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # SRM Respondent Home UI
+
 User Interface for respondents to access ONS Survey Data Collection questionnaires and services
 
 ## Installation/build
+
 To install all dependencies and download the templates run:
+
 ```shell
 make install
 ```
 
 To build the docker image and run the tests:
+
 ```shell
 make build
 ```
@@ -15,6 +19,7 @@ make build
 ## Running
 
 Once that's done, you can run the make command to run it in your terminal:
+
 ```shell
 make run
 ```
@@ -22,32 +27,78 @@ make run
 or to run it in Pycharm, use the run template that's specified and it should work as expected.
 
 ## Translations
+
 The site uses babel for translations.
 
-Text to translate is marked up in html and py templates and files, then a messages.pot is build via pybabel, which collates all the text to translate into a single file.
+Text to translate is marked up in html and py templates and files, then a messages.pot is build via pybabel, which
+collates all the text to translate into a single file.
 
 To build/re-build the translation messages.pot use:
 
 ```
 pipenv run pybabel extract -F babel.cfg -o app/translations/messages.pot .
 ```
-    
-To create a new language messages file, run the following, changing the 2 character language code at the end to the required language code. Only generate a individual language file once.
 
-Note that this implementation includes an English translation. This is needed due to an issue with implementing pybabel with aiohttp.
+To create a new language messages file, run the following, changing the 2 character language code at the end to the
+required language code. Only generate a individual language file once.
+
+Note that this implementation includes an English translation. This is needed due to an issue with implementing pybabel
+with aiohttp.
 
 ```
 pipenv run pybabel init -i app/translations/messages.pot -d app/translations -l cy
 ```
 
-Once created, you can update the existing language messages.po files to include changes in the messages.pot by running the following. This will update ALL language files.
+Once created, you can update the existing language messages.po files to include changes in the messages.pot by running
+the following. This will update ALL language files.
 
 ```
 pipenv run pybabel update -i app/translations/messages.pot -d app/translations
 ```
-    
+
 To compile updates to the messages.po files into messages.mo (the file actually used by the site) use:
 
 ```
 pipenv run pybabel compile -d app/translations
 ```
+
+## Venom Tests
+
+We have a suite of [Venom tests](https://github.com/ovh/venom) for testing the OWASP header recommendations. These tests
+are copied from the [OWASP Secure Headers Project](https://github.com/oshp/oshp-validator).
+
+See [./tests/venom_tests.yml](./tests/venom_tests.yml).
+
+These tests are designed to be run against a public HTTPS endpoint in a prod-like environment, since some of the headers
+they check must not be present on HTTP responses e.g.
+the [HSTS header](https://www.rfc-editor.org/rfc/rfc6797#section-6.1). Hence, these tests cannot all pass when run
+against a local HTTP only instance. However, it may be useful for development to still run them locally.
+
+### Running Venom locally
+
+* First, use our [docker dev](https://github.com/ONSdigital/ssdc-rm-docker-dev) to run our local development
+  environment.
+  This will run RH UI at `http://localhost:9092`.
+
+* Now create a local copy of the venom test suite with the correct URL substituted in:
+
+  ```shell
+  sed -e "s|<VENOM_TARGET_URL>|http://host.docker.internal:9092/en/start|" ./tests/venom_tests.yml > tmp_venom_local.yml
+  ```
+
+  It may be helpful to now open the created `tmp_venom_local.yml` file in an editor and comment out the HSTS header test
+  which is bound to fail locally.
+
+* Now run the tests against the docker dev RH UI using the official OVH Venom docker image (
+  See https://github.com/ovh/venom?tab=readme-ov-file#docker-image for more details on running venom and docs on
+  configuration).
+
+  ```shell
+  mkdir -p tmp_venom_results
+  docker run --network="ssdcrmdockerdev_default" \
+    --mount type=bind,source=$(pwd)/tmp_venom_local.yml,target=/workdir/tests/tests.yml \
+    --mount type=bind,source=$(pwd)/tmp_venom_results,target=/workdir/results \
+    ovhcom/venom:latest 
+  ```
+
+* The test results should be shown in your terminal, and details logs written in the `tmp_venom_results` folder.

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ against a local HTTP only instance. However, it may be useful for development to
   sed -e "s|<VENOM_TARGET_URL>|http://host.docker.internal:9092/en/start|" ./tests/venom_tests.yml > tmp_venom_local.yml
   ```
 
-  It may be helpful to now open the created `tmp_venom_local.yml` file in an editor and comment out the HSTS header test
-  which is bound to fail locally.
+  It may be helpful to now open the created `tmp_venom_local.yml` file in an editor and comment out the
+  `Strict-Transport-Security` test case which is bound to fail locally.
 
 * Now run the tests against the docker dev RH UI using the official OVH Venom docker image (
   See https://github.com/ovh/venom?tab=readme-ov-file#docker-image for more details on running venom and docs on

--- a/README.md
+++ b/README.md
@@ -77,8 +77,7 @@ against a local HTTP only instance. However, it may be useful for development to
 ### Running Venom locally
 
 * First, use our [docker dev](https://github.com/ONSdigital/ssdc-rm-docker-dev) to run our local development
-  environment.
-  This will run RH UI at `http://localhost:9092`.
+  environment to test against.
 
 * Now create a local copy of the venom test suite with the correct URL substituted in:
 

--- a/tests/venom_tests.yml
+++ b/tests/venom_tests.yml
@@ -126,6 +126,7 @@ testcases:
         url: '{{.target_site}}'
         skip_body: true
         info: >-
+          (Checking that Feature Policy is not in the header)
           This header has now been renamed to Permissions-Policy in the
           specification.
         timeout: '{{.request_timeout_in_seconds}}'
@@ -139,6 +140,7 @@ testcases:
         url: '{{.target_site}}'
         skip_body: true
         info: >-
+          (Checking that Public Key Pins is not in the header)
           This header has been deprecated by all major browsers and is no longer
           recommended. Avoid using it, and update existing code if possible!
         timeout: '{{.request_timeout_in_seconds}}'
@@ -152,6 +154,7 @@ testcases:
         url: '{{.target_site}}'
         skip_body: true
         info: >-
+          (Checking that Expect CT is not in the header)
           This header will likely become obsolete in June 2021. Since May 2018
           new certificates are expected to support SCTs by default. Certificates
           before March 2018 were allowed to have a lifetime of 39 months, those
@@ -167,6 +170,7 @@ testcases:
         url: '{{.target_site}}'
         skip_body: true
         info: >-
+          (Checking that X-XSS Protection is not in the header)
           The X-XSS-Protection header has been deprecated by modern browsers and
           its use can introduce additional security issues on the client side.
         timeout: '{{.request_timeout_in_seconds}}'

--- a/tests/venom_tests.yml
+++ b/tests/venom_tests.yml
@@ -3,7 +3,7 @@ name: HTTP security response headers test suites
 # VENOM HOME: https://github.com/ovh/venom
 
 vars:
-  target_site: ${VENOM_TARGET_URL}
+  target_site: <VENOM_TARGET_URL>
   request_timeout_in_seconds: 20
 testcases:
   ###############################################

--- a/tests/venom_tests.yml
+++ b/tests/venom_tests.yml
@@ -3,6 +3,8 @@ name: HTTP security response headers test suites
 # VENOM HOME: https://github.com/ovh/venom
 
 vars:
+  # The target URL must be substituted in before running these tests
+  # e.g. using sed like such `sed -e "s|<VENOM_TARGET_URL>|https://example-rh-ui/en/start|" <path/to/venom_tests.yml> > venom-tests.yml`
   target_site: <VENOM_TARGET_URL>
   request_timeout_in_seconds: 20
 testcases:

--- a/tests/venom_tests.yml
+++ b/tests/venom_tests.yml
@@ -1,0 +1,175 @@
+name: HTTP security response headers test suites
+# TOOLS
+# VENOM HOME: https://github.com/ovh/venom
+
+vars:
+  target_site: ${VENOM_TARGET_URL}
+  request_timeout_in_seconds: 20
+testcases:
+  ###############################################
+  ## ACTIVE RECOMMENDED AND WORKING DRAFT HEADERS
+  ###############################################
+  - name: Strict-Transport-Security
+    steps:
+      - type: http
+        method: GET
+        url: '{{.target_site}}'
+        skip_body: true
+        timeout: '{{.request_timeout_in_seconds}}'
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.headers.strict-transport-security ShouldNotBeNil
+          - result.headers.strict-transport-security ShouldEqual "max-age=31536000; includeSubDomains"
+  - name: X-Frame-Options
+    steps:
+      - type: http
+        method: GET
+        url: '{{.target_site}}'
+        skip_body: true
+        timeout: '{{.request_timeout_in_seconds}}'
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.headers.x-frame-options ShouldNotBeNil
+          - result.headers.x-frame-options ShouldBeIn "deny" "DENY"
+  - name: X-Content-Type-Options
+    steps:
+      - type: http
+        method: GET
+        url: '{{.target_site}}'
+        skip_body: true
+        timeout: '{{.request_timeout_in_seconds}}'
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.headers.x-content-type-options ShouldNotBeNil
+          - result.headers.x-content-type-options ShouldEqual "nosniff"
+  - name: Content-Security-Policy
+    steps:
+      - type: http
+        method: GET
+        url: '{{.target_site}}'
+        skip_body: true
+        timeout: '{{.request_timeout_in_seconds}}'
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.headers.content-security-policy ShouldNotBeNil
+          - result.headers.content-security-policy ShouldNotContainSubstring "unsafe"
+  - name: X-Permitted-Cross-Domain-Policies
+    steps:
+      - type: http
+        method: GET
+        url: '{{.target_site}}'
+        skip_body: true
+        timeout: '{{.request_timeout_in_seconds}}'
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.headers.x-permitted-cross-domain-policies ShouldNotBeNil
+          - result.headers.x-permitted-cross-domain-policies ShouldEqual "None"
+  - name: Referrer-Policy
+    steps:
+      - type: http
+        method: GET
+        url: '{{.target_site}}'
+        skip_body: true
+        timeout: '{{.request_timeout_in_seconds}}'
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.headers.referrer-policy ShouldNotBeNil
+          - result.headers.referrer-policy ShouldEqual "strict-origin-when-cross-origin"
+  - name: Cross-Origin-Opener-Policy
+    steps:
+      - type: http
+        method: GET
+        url: '{{.target_site}}'
+        skip_body: true
+        timeout: '{{.request_timeout_in_seconds}}'
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.headers.cross-origin-opener-policy ShouldNotBeNil
+          - result.headers.cross-origin-opener-policy ShouldEqual "same-origin"
+  - name: Cross-Origin-Resource-Policy
+    steps:
+      - type: http
+        method: GET
+        url: '{{.target_site}}'
+        skip_body: true
+        timeout: '{{.request_timeout_in_seconds}}'
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.headers.cross-origin-resource-policy ShouldNotBeNil
+          - result.headers.cross-origin-resource-policy ShouldEqual "same-site"
+  - name: Permissions-Policy
+    steps:
+      - type: http
+        method: GET
+        url: '{{.target_site}}'
+        skip_body: true
+        timeout: '{{.request_timeout_in_seconds}}'
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.headers.permissions-policy ShouldNotBeNil
+          - result.headers.permissions-policy ShouldEqual "accelerometer=(),autoplay=(),camera=(),display-capture=(),document-domain=(),encrypted-media=(),fullscreen=(),geolocation=(),gyroscope=(),magnetometer=(),microphone=(),midi=(),payment=(),picture-in-picture=(),publickey-credentials-get=(),screen-wake-lock=(),sync-xhr=(self),usb=(),xr-spatial-tracking=()"
+  - name: Cache-Control
+    steps:
+      - type: http
+        method: GET
+        url: '{{.target_site}}'
+        skip_body: true
+        timeout: '{{.request_timeout_in_seconds}}'
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.headers.cache-control ShouldNotBeNil
+          - 'result.headers.cache-control ShouldEqual "no-store max-age=0"'
+  - name: Feature-Policy
+    steps:
+      - type: http
+        method: GET
+        url: '{{.target_site}}'
+        skip_body: true
+        info: >-
+          This header has now been renamed to Permissions-Policy in the
+          specification.
+        timeout: '{{.request_timeout_in_seconds}}'
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.headers.feature-policy ShouldBeNil
+  - name: Public-Key-Pins
+    steps:
+      - type: http
+        method: GET
+        url: '{{.target_site}}'
+        skip_body: true
+        info: >-
+          This header has been deprecated by all major browsers and is no longer
+          recommended. Avoid using it, and update existing code if possible!
+        timeout: '{{.request_timeout_in_seconds}}'
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.headers.public-key-pins ShouldBeNil
+  - name: Expect-CT
+    steps:
+      - type: http
+        method: GET
+        url: '{{.target_site}}'
+        skip_body: true
+        info: >-
+          This header will likely become obsolete in June 2021. Since May 2018
+          new certificates are expected to support SCTs by default. Certificates
+          before March 2018 were allowed to have a lifetime of 39 months, those
+          will all be expired in June 2021.
+        timeout: '{{.request_timeout_in_seconds}}'
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.headers.expect-ct ShouldBeNil
+  - name: X-Xss-Protection
+    steps:
+      - type: http
+        method: GET
+        url: '{{.target_site}}'
+        skip_body: true
+        info: >-
+          The X-XSS-Protection header has been deprecated by modern browsers and
+          its use can introduce additional security issues on the client side.
+        timeout: '{{.request_timeout_in_seconds}}'
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.headers.x-xss-protection ShouldBeNil

--- a/tests/venom_tests.yml
+++ b/tests/venom_tests.yml
@@ -4,7 +4,7 @@ name: HTTP security response headers test suites
 
 vars:
   # The target URL must be substituted in before running these tests
-  # e.g. using sed like such `sed -e "s|<VENOM_TARGET_URL>|https://example-rh-ui/en/start|" <path/to/venom_tests.yml> > venom-tests.yml`
+  # e.g. using sed like such `sed -e "s|<VENOM_TARGET_URL>|https://example-rh-ui/en/start|" <./tests/venom_tests.yml> > example_venom_tests.yml`
   target_site: <VENOM_TARGET_URL>
   request_timeout_in_seconds: 20
 testcases:


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To make the venom security tests more re-usable, the test config file has been removed from the baked docker image and now needs to live and be fetched from somewhere else. It makes most sense to me for it to live in the RH UI repo, with the code it is testing.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Add venom test yml
- Add README section on Venom tests

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
See the linked PRs, this has been tested in a dev pipeline already.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://jira.ons.gov.uk/browse/SDCSRM-521