### PR TITLE
SDCSSRM 642 View Cookies button redirect fix

### DIFF
--- a/rh_ui/templates/base.html
+++ b/rh_ui/templates/base.html
@@ -12,6 +12,7 @@
         'statementTitle': _('Cookies'),
         'serviceName': '',
         'settingsLinkURL': cookiesPageURL,
+        'settingsLinkTextURL': cookiesPageURL,
         'statementText': _("To collect information about how you use this website, we use%(open_cookies_link)s cookies.%(close_link)s</br>
                         This information helps us improve our services and make sure that the website works as well as possible.",
                         open_cookies_link='<a href="%s">' % cookiesPageURL, close_link='</a>'),

--- a/rh_ui/templates/base.html
+++ b/rh_ui/templates/base.html
@@ -11,7 +11,6 @@
         'lang': g.lang_code,
         'statementTitle': _('Cookies'),
         'serviceName': '',
-        'settingsLinkURL': cookiesPageURL,
         'settingsLinkTextURL': cookiesPageURL,
         'statementText': _("To collect information about how you use this website, we use%(open_cookies_link)s cookies.%(close_link)s</br>
                         This information helps us improve our services and make sure that the website works as well as possible.",


### PR DESCRIPTION
# Motivation and Context
When you press view cookies button on the cookies banner it would take you to a non existant page, as it was missing the language prefix

# What has changed
added settingLinkTextURl

# How to test?
Build it, and check you can access it in english and welsh

# Links
[Jira SDCSRM-624](https://jira.ons.gov.uk/browse/SDCSRM-624)

# Screenshots (if appropriate):
