### PR TITLE
Investigate CSP Misconfiguration

### DIFF
--- a/rh_ui/security.py
+++ b/rh_ui/security.py
@@ -1,6 +1,9 @@
 from flask import Blueprint
 
 CSP = {
+    'base-uri': [
+        "'none'"
+    ],
     'default-src': [
         "'self'",
         'https://cdn.ons.gov.uk',
@@ -11,6 +14,7 @@ CSP = {
         'https://cdn.ons.gov.uk',
     ],
     'script-src': [
+        "'strict-dynamic'",
         "'self'",
         'https://cdn.ons.gov.uk',
         'https://www.googletagmanager.com',


### PR DESCRIPTION
# Motivation and Context
There was a low level security alert was raised for CSP header issue within production where the CSP header is flagging an issue due to the way external content is loaded

# What has changed
I've added in strict-dynamic into script-src. From what I understood from research this is all we need to do as we already have a nonce included in the CSP header and the nonce is already being passed to the relevant resources.
Something to note is that with CSP v3, if strict-dynamic is enabled, it will override 'self' and the domains making them redundant, however I've left them in for backwards compatibility with CSP versions 1 & 2.

Using https://csp-evaluator.withgoogle.com/ and a guide on testing CSP (https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/12-Test_for_Content_Security_Policy), I've decided to also add in `base-uri` to the header which 'directive specifies the base URL for resolving relative URLs in the page. Without this directive, the page becomes vulnerable to HTML base tag injection attacks.'

# How to test?
- Build the change and check the changes are present in the CSP header. (double check the nonce is present in the script-src feild)
- Paste the header into a CSP header evaluator (I used https://csp-evaluator.withgoogle.com/), and check there isn't anything missing with all versions of CSP
- Test you can still use the page as expected
- Run the AT against RH-UI in your gcp project to check it's all working as expected

# Links
https://officefornationalstatistics.atlassian.net/browse/SDCSRM-999

# Screenshots (if appropriate)
