### PR TITLE
SDCSRM-1096 Return to previous page link on cookies broken

### DIFF
--- a/rh_ui/templates/info_pages/cookies.html
+++ b/rh_ui/templates/info_pages/cookies.html
@@ -31,7 +31,7 @@
     <h2>{{ _('Your cookie settings have been saved') }}</h2>
     <p>{{ _('Some parts of start.surveys.ons.gov.uk may use additional cookies and will have their own cookie policy and
             banner.') }}</p>
-    <a class="ons-js-return-link ons-u-mt-s ons-u-dib" href="#0">{{ _('Return to previous page') }}</a>
+    <a class="ons-js-return-link ons-u-mt-s ons-u-dib" href="{{ url_for('i18n.start_bp.start_get') }}">{{ _('Return to previous page') }}</a>
 {% endcall %}
 <h1 class="ons-u-fs-2xl">{{ _('Cookies on start.surveys.ons.gov.uk') }}</h1>
 <p>{{ _('Cookies are small files saved on your device when you visit a website.') }}</p>


### PR DESCRIPTION
# Motivation and Context
A resubmission error will appear if you 
1. Press the access study with an invalid code
2. Navigate to the cookies page
3. Save changes on the cookies page
4. Click `Return to previous page link`, 

Instead of showing the start page, you’ll see a Confirm Form Resubmission page

# What has changed
- Removed a placeholder href link to the url to the actual start page.

It looks like we still use the placeholder for the href link, this will go back to the previous request, which in this case is a POST on the start page.

# How to test?
Try the same journey that caused the bug
Try the journey but don't attempt to post before saving cookies

# Links
https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1096

# Screenshots (if appropriate)
