### PR TITLE
SDCSRM-1591: Bump python runtime base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY Pipfile* /app/
 
 RUN /root/.local/bin/pipenv sync
 
-FROM python:3.12.12-slim@sha256:dc9e92fcdc085ad86dda976f4cfc58856dba33a438a16db37ff00151b285c8ca
+FROM python:3.12.13-slim@sha256:a9e4190f02729f01e5b3719bd8b3ea0f8d9350dc17d01a1ce1ca6e3fbfcf7a99
 
 RUN groupadd -g 984 respondenthome && useradd -r -u 984 -g respondenthome respondenthome
 


### PR DESCRIPTION
# Motivation and Context
Security Command Center flagged OS-package vulnerabilities (openssl, glibc, perl, ...) in the Python runtime image. This bumps the pinned `python:3.12-slim` runtime base to clear them.

# What has changed
* Bumped the pinned runtime base `python:3.12.12-slim@sha256:dc9e...` -> `python:3.12.13-slim@sha256:a9e4...` — the same digest ONSdigital/ssdc-rm-dockerfiles#77 pins for the `python-pipenv` build image, keeping build and runtime bases consistent. (The build stage tracks the floating `python-pipenv:3.12` tag, so it needs no change here.)

# How to test?
Built and tested in an isolated container on the new base:
```bash
docker build --platform linux/amd64 -t rh-ui:test .
```
`make install unit_test` passes (22 passed, 97% coverage, flake8 + vulture clean) and the `pipenv sync` build stage completes on the new base.

# Links
* [SDCSRM-1591](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1591)
* ONSdigital/ssdc-rm-dockerfiles#77


[SDCSRM-1591]: https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ